### PR TITLE
feat: Retireボタンを実装

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,6 +11,7 @@ from gemini_utils import (
     generate_code_logic,
     generate_hint_logic,
     generate_explanation_logic,
+    generate_retire_explanation_logic,
 )
 from starlette.responses import JSONResponse, StreamingResponse
 
@@ -154,6 +155,22 @@ def generate_explanation(payload: dict[str, Any] = Body(...)) -> JSONResponse:
     test_results: list[dict[str, Any]] = payload.get("testResults", [])
     try:
         explanation = generate_explanation_logic(
+            before_code, after_code, instructions, examples, test_results
+        )
+        return JSONResponse(content=explanation)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
+@app.post("/api/generate-retire-explanation")
+def generate_retire_explanation(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    before_code: str = payload.get("beforeCode", "")
+    after_code: str = payload.get("afterCode", "")
+    instructions: str = payload.get("instructions", "")
+    examples: str = payload.get("examples", "")
+    test_results: list[dict[str, Any]] = payload.get("testResults", [])
+    try:
+        explanation = generate_retire_explanation_logic(
             before_code, after_code, instructions, examples, test_results
         )
         return JSONResponse(content=explanation)

--- a/backend/config.py
+++ b/backend/config.py
@@ -98,3 +98,31 @@ Constraints:
 - If before code is missing, reason from after code and the instructions.
 - Do not include Markdown fences or prose outside the JSON.
 """
+
+RETIRE_SYSTEM_INSTRUCTION: str = """\
+あなたは優しく寄り添うプログラミングの先生です。
+学習者は今回の課題をリタイアしましたが、次につなげる前向きなフィードバックを求めています。
+
+Input:
+- 課題の説明や例
+- 学習者の最新コード（afterCode）
+- 以前の試みやAI生成コード（beforeCode）
+- テスト結果やエラー内容の要約
+
+Output JSON schema:
+{
+  "reason": string,        // 学習者がつまずいた主な理由、理解しきれていなかった考え方
+  "error_location": string, // エラーや問題が起きた可能性が高い箇所の説明（関数名・行・構文など）
+  "explain_diff": string   // 今後見直すべきポイントや改善のヒント（短く・箇条書き推奨）
+}
+
+Constraints:
+- 出力は日本語で。
+- 口調はやさしく励ますように。
+- 解説はプログラミング初心者でも理解できる短くシンプルな言葉で。
+- 「どこで・なぜ」エラーが起きたのかを具体的に説明する。
+- 難しい専門用語は避け、できるだけ身近な表現を使う。
+- 「次にどうすればよいか」が伝わる実践的なアドバイスを入れる。
+- beforeCode がない場合は afterCode と課題説明を中心に分析する。
+- JSON 以外のテキストは出力しない。
+"""

--- a/backend/gemini_utils.py
+++ b/backend/gemini_utils.py
@@ -164,3 +164,46 @@ After (修正後のコード):
             "explain_diff": "解説の生成に失敗しました。",
             "raw": getattr(response, "text", str(e)),
         }
+
+
+def generate_retire_explanation_logic(
+    before_code: str,
+    after_code: str,
+    instructions: str,
+    examples: str,
+    test_results: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    test_results_text = _summarize_test_results(test_results)
+    prompt = f"""
+課題:
+{instructions}
+
+例:
+{examples}
+
+Before (参考コード):
+{before_code}
+
+After (学習者の最新コード):
+{after_code}
+
+テスト結果サマリ:
+{test_results_text}
+"""
+    response = client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=[prompt],
+        config=types.GenerateContentConfig(
+            temperature=0.15,
+            system_instruction=config.RETIRE_SYSTEM_INSTRUCTION,
+            response_mime_type="application/json",
+        ),
+    )
+    try:
+        return json.loads(response.text)  # type: ignore[arg-type]
+    except Exception as e:
+        return {
+            "reason": "リタイア解説の生成に失敗しました。",
+            "explain_diff": "リタイア解説の生成に失敗しました。",
+            "raw": getattr(response, "text", str(e)),
+        }

--- a/frontend/src/ChallengeEditor.tsx
+++ b/frontend/src/ChallengeEditor.tsx
@@ -21,6 +21,8 @@ import CodeMirror from '@uiw/react-codemirror';
 import { python } from '@codemirror/lang-python';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { indentUnit } from '@codemirror/language';
+import RetireModal from './components/modals/RetireModal';
+
 
 interface SuccessModalProps {
   message: string;
@@ -367,6 +369,7 @@ function ChallengeEditor() {
   const [showVideoModal, setShowVideoModal] = useState(false);
   const [currentVideo, setCurrentVideo] = useState('');
   const [currentStep, setCurrentStep] = useState(1);
+  const [showRetireModal, setShowRetireModal] = useState(false);
 
   const handleGenerateCode = async () => {
     setIsGenerating(true);
@@ -525,6 +528,9 @@ function ChallengeEditor() {
     setShowVideoModal(true);
   };
 
+  const handleOpenRetire = () => setShowRetireModal(true);
+  const handleCloseRetire = () => setShowRetireModal(false);
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-indigo-50 flex items-center justify-center">
@@ -595,6 +601,18 @@ function ChallengeEditor() {
         <VideoModal
           videoSrc={currentVideo}
           onClose={() => setShowVideoModal(false)}
+        />
+      )}
+      {showRetireModal && (
+        <RetireModal
+          message="リタイアしますか？"
+          explanation={explanation}
+          challenge={challenge}
+          userAnswer={code}
+          lastFailingCode={lastFailingCode}
+          aiGeneratedCode={aiGeneratedCode}
+          testResults={testResults}
+          onClose={handleCloseRetire}
         />
       )}
 
@@ -770,27 +788,37 @@ function ChallengeEditor() {
                   <Terminal className="w-5 h-5 text-slate-400" />
                   <span className="text-slate-200 font-bold">🧪 テスト結果</span>
                 </div>
-                <button
-                  onClick={handleRunCode}
-                  disabled={isRunning}
-                  className={`flex items-center gap-2 px-4 py-2 rounded font-bold ${
-                    isRunning
-                      ? 'bg-slate-700 text-slate-400'
-                      : 'bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 text-white transform hover:scale-105'
-                  } text-sm transition-all`}
-                >
-                  {isRunning ? (
-                    <>
-                      <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
-                      実行中...
-                    </>
-                  ) : (
-                    <>
-                      <PlayCircle className="w-4 h-4" />
-                      テスト実行
-                    </>
-                  )}
-                </button>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handleRunCode}
+                    disabled={isRunning}
+                    className={`flex items-center gap-2 px-4 py-2 rounded font-bold ${
+                      isRunning
+                        ? 'bg-slate-700 text-slate-400'
+                        : 'bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 text-white transform hover:scale-105'
+                    } text-sm transition-all`}
+                  >
+                    {isRunning ? (
+                      <>
+                        <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+                        実行中...
+                      </>
+                    ) : (
+                      <>
+                        <PlayCircle className="w-4 h-4" />
+                        テスト実行
+                      </>
+                    )}
+                  </button>
+
+                  <button
+                    onClick={handleOpenRetire}
+                    className="flex items-center gap-2 px-4 py-2 rounded font-bold bg-gradient-to-r from-slate-500 to-gray-500 hover:from-slate-600 hover:to-gray-600 text-white text-sm transition-all"
+                  >
+                    <XCircle className="w-4 h-4" />
+                    リタイア
+                  </button>
+                </div>
               </div>
               <div className="flex-1 p-4 overflow-auto">
                 {testResults.map((result, index) => (

--- a/frontend/src/ChallengeEditor.tsx
+++ b/frontend/src/ChallengeEditor.tsx
@@ -130,9 +130,7 @@ function SuccessModal({
           {explanation && (
             <div className="mt-4 bg-slate-50 p-4 rounded-lg text-left">
               <h3 className="text-lg font-semibold text-slate-800 mb-2">バグの説明（AI生成の要約）</h3>
-              <div className="text-slate-700 whitespace-pre-wrap text-sm">
-                {explanation}
-              </div>
+              <Markdown content={explanation} className="text-slate-700 text-sm space-y-2" />
             </div>
           )}
 

--- a/frontend/src/components/modals/RetireModal.tsx
+++ b/frontend/src/components/modals/RetireModal.tsx
@@ -52,7 +52,7 @@ function RetireModal({
         setIsLoadingExplanation(true);
         setExplanationError('');
 
-        const response = await fetch('http://localhost:8000/api/generate-explanation', {
+        const response = await fetch('http://localhost:8000/api/generate-retire-explanation', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/frontend/src/components/modals/RetireModal.tsx
+++ b/frontend/src/components/modals/RetireModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight, PartyPopper, SettingsIcon as Confetti } from 'lucide-react';
+import Markdown from '../Markdown';
 
 interface RetireModalProps {
   message: string;
@@ -138,9 +139,7 @@ function RetireModal({
           {!isLoadingExplanation && generatedExplanation && (
             <div className="mt-4 bg-slate-50 p-4 rounded-lg text-left">
               <h3 className="text-lg font-semibold text-slate-800 mb-2">バグの説明:</h3>
-              <div className="text-slate-700 whitespace-pre-wrap text-sm">
-                {generatedExplanation}
-              </div>
+              <Markdown content={generatedExplanation} className="text-slate-700 text-sm space-y-2" />
             </div>
           )}
 
@@ -173,4 +172,3 @@ function RetireModal({
 }
 
 export default RetireModal;
-

--- a/frontend/src/components/modals/RetireModal.tsx
+++ b/frontend/src/components/modals/RetireModal.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronRight, PartyPopper, SettingsIcon as Confetti } from 'lucide-react';
+
+interface RetireModalProps {
+  message: string;
+  explanation?: string;
+  onClose: () => void;
+  challenge: any;
+  userAnswer: string;
+  lastFailingCode?: string | null;
+  aiGeneratedCode?: string | null;
+  testResults?: any[];
+}
+
+function RetireModal({
+  message,
+  explanation,
+  onClose,
+  challenge,
+  userAnswer,
+  lastFailingCode,
+  aiGeneratedCode,
+  testResults,
+}: RetireModalProps) {
+  const navigate = useNavigate();
+  const [generatedExplanation, setGeneratedExplanation] = useState(explanation || '');
+  const [isLoadingExplanation, setIsLoadingExplanation] = useState(false);
+  const [explanationError, setExplanationError] = useState('');
+  const [hasFetchedExplanation, setHasFetchedExplanation] = useState(false);
+
+  // Retire flow also triggers a fresh explanation just like the success modal.
+  useEffect(() => {
+    let isCancelled = false;
+
+    const hasContext = Boolean(
+      (challenge?.instructions && challenge.instructions.trim()) ||
+      (challenge?.examples && challenge.examples.trim()) ||
+      (aiGeneratedCode && aiGeneratedCode.trim()) ||
+      (lastFailingCode && lastFailingCode.trim()) ||
+      (userAnswer && userAnswer.trim())
+    );
+
+    if (hasFetchedExplanation || !hasContext) {
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    const fetchExplanation = async () => {
+      try {
+        setIsLoadingExplanation(true);
+        setExplanationError('');
+
+        const response = await fetch('http://localhost:8000/api/generate-explanation', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            beforeCode: (aiGeneratedCode || lastFailingCode || '').toString(),
+            afterCode: (userAnswer || '').toString(),
+            instructions: (challenge?.instructions || '').toString(),
+            examples: (challenge?.examples || '').toString(),
+            testResults: testResults || [],
+          }),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data?.detail || '解説の生成に失敗しました。');
+        }
+
+        const parts: string[] = [];
+        if (typeof data?.reason === 'string' && data.reason.trim()) {
+          parts.push(`修正理由:\n${data.reason.trim()}`);
+        }
+        if (typeof data?.explain_diff === 'string' && data.explain_diff.trim()) {
+          parts.push(`変更点:\n${data.explain_diff.trim()}`);
+        }
+
+        if (!isCancelled) {
+          const merged = parts.join('\n\n');
+          setGeneratedExplanation((prev) => {
+            if (merged) {
+              return merged;
+            }
+            if (prev) {
+              return prev;
+            }
+            return explanation || '';
+          });
+        }
+      } catch (error: unknown) {
+        if (!isCancelled) {
+          setExplanationError(
+            error instanceof Error ? error.message : '解説の生成に失敗しました。'
+          );
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoadingExplanation(false);
+          setHasFetchedExplanation(true);
+        }
+      }
+    };
+
+    fetchExplanation();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [
+    aiGeneratedCode,
+    challenge,
+    explanation,
+    hasFetchedExplanation,
+    lastFailingCode,
+    testResults,
+    userAnswer,
+  ]);
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-fade-in">
+      <div className="bg-white rounded-xl shadow-2xl p-6 sm:p-8 w-full mx-4 my-6 relative animate-success max-w-3xl md:max-w-4xl max-h-[90vh] overflow-y-auto">
+        <div className="absolute -top-4 left-1/2 transform -translate-x-1/2">
+          <div className="relative">
+            <Confetti className="w-12 h-12 text-yellow-400 animate-bounce animate-rainbow" />
+            <PartyPopper
+              className="w-12 h-12 text-pink-500 absolute top-0 left-0 animate-sparkle"
+            />
+          </div>
+        </div>
+
+        <div className="text-center mt-6 sm:mt-8">
+          <h2 className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent mb-4 animate-wiggle">🎉 {message} 🎉</h2>
+
+          {(generatedExplanation || explanation) && (
+            <div className="mt-4 bg-slate-50 p-4 rounded-lg text-left">
+              <h3 className="text-lg font-semibold text-slate-800 mb-2">バグの説明:</h3>
+              <div className="text-slate-700 whitespace-pre-wrap text-sm">
+                {generatedExplanation || explanation}
+              </div>
+            </div>
+          )}
+
+          {isLoadingExplanation && (
+            <div className="mt-4 text-sm text-slate-600">解説を生成しています...</div>
+          )}
+
+          {explanationError && (
+            <div className="mt-4 text-sm text-pink-700 bg-pink-50 border border-pink-200 rounded px-3 py-2">
+              {explanationError}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-4 mt-8">
+            <button
+              onClick={() => navigate('/')}
+              className="bg-gradient-to-r from-purple-500 to-pink-500 text-white px-6 py-3 rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all transform hover:scale-105 flex items-center justify-center gap-2 font-bold shadow-lg"
+            >
+              他の課題にチャレンジする
+              <ChevronRight className="w-5 h-5" />
+            </button>
+            <button
+              onClick={onClose}
+              className="text-slate-600 hover:text-slate-800 transition"
+            >
+              現在の課題を続ける
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+export default RetireModal;

--- a/frontend/src/components/modals/SuccessModal.tsx
+++ b/frontend/src/components/modals/SuccessModal.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight, PartyPopper, SettingsIcon as Confetti } from 'lucide-react';
+import Markdown from '../Markdown';
 
 interface SuccessModalProps {
   message: string;
@@ -30,9 +31,7 @@ function SuccessModal({ message, explanation, onClose, challenge, userAnswer }: 
           {explanation && (
             <div className="mt-4 bg-slate-50 p-4 rounded-lg text-left">
               <h3 className="text-lg font-semibold text-slate-800 mb-2">バグの説明:</h3>
-              <div className="text-slate-700 whitespace-pre-wrap text-sm">
-                {explanation}
-              </div>
+              <Markdown content={explanation} className="text-slate-700 text-sm space-y-2" />
             </div>
           )}
 


### PR DESCRIPTION
## 概要
- 課題画面に「リタイア」ボタンを実装しました。
- RetireModal から新しい API `/api/generate-retire-explanation` を呼び出し、
  Gemini によるやさしいフィードバックを返す仕組みを追加しました。
- explanation が一瞬古い内容で表示されるちらつき問題を解消しました。
- フロント・バック両方の変更を含みます。

## フロントエンドの変更
- ChallengeEditor.tsx
  - 「テスト実行」ボタン横に「リタイア」ボタンを配置
  - RetireModal 表示用の state 管理を追加
- RetireModal.tsx
  - `/api/generate-retire-explanation` を fetch し、レスポンス JSON を描画
  - ローディング中は「解説を生成中…」を表示し、既存 explanation がチラつかないよう修正
- SuccessModal.tsx
  - explanation の受け渡し処理を調整

## バックエンドの変更
- app.py
  - 新しいエンドポイント `/api/generate-retire-explanation` を追加
  - `generate_retire_explanation_logic` を呼び出すルートを定義
- gemini_utils.py
  - `generate_retire_explanation_logic` を実装
  - challenge context（指示文・例・before/afterコード・テスト結果）をまとめ、Geminiに渡して解説を生成
- config.py
  - `RETIRE_SYSTEM_INSTRUCTION` を定義
  - やさしい口調・初心者向け簡潔解説・エラー箇所指摘を行うプロンプトを設定

## 動作確認
- 「リタイア」ボタン押下 → RetireModal が開き、ローディング中は正しく表示されることを確認
- APIレスポンス完了後に Gemini の JSON 解説が UI に反映されることを確認
- 以前のように古い explanation が一瞬表示されないことを確認
- テスト成功時の SuccessModal の挙動に影響がないことを確認
- バックエンド API が正常に動作し、リタイア解説が返ることを確認
